### PR TITLE
Rewrite comment containing vulgar language

### DIFF
--- a/sblpy/core.py
+++ b/sblpy/core.py
@@ -70,7 +70,7 @@ async def construct_fake_context(bot, channel: discord.TextChannel, author):
         ctx.author = author
         break
 
-    return ctx  # says undefined, fuck off pycharm it IS defined.
+    return ctx  # It says "undefined," but PyCharm is incorrect—it is defined.
 
 
 class SBLP:


### PR DESCRIPTION
It's important to maintain a professional and respectful tone throughout the codebase. I have rewritten a comment, containing words that may offend some people and/or contain vulgar and inappropriate language. 